### PR TITLE
@axe-core/playwright をインストールし、全ページ自動でA11yのテストが走るように。

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ coverage/
 # Vite
 .vite
 .vite_cache/
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
-# eleventy_test
-eleventyでのローカル開発環境のテストです
+# eleventy_test_dam
+
+## 簡易な説明
+- [こちらの記事](https://azukiazusa.dev/blog/axe-core-playwright/)をベースに、`@axe-core/playwright`を活用してテストを行っています。
+- `npm run test:a11y`でplaywrightが実行され、テスト結果が出力されます。
+  - 詳しいテスト結果は、ターミナルでも出力されていると思いますが`http://localhost:9323/`にアクセスすることで見ることができます。
+- `playwright.config.js`の`webServer`に記載の通り、テスト開始時に`npm run serve`が実行され、ローカル環境を対象にテストが実行されます。
+- Eleventyの[Collection API](https://www.11ty.dev/docs/collections-api/)を利用してページ一覧を生成し、それを元に全ページをクロールする感じになってます。
+  - なので、Eleventyを使わないプロジェクトでは`sitemap.xml`を使う感じになりそうですね。
+- 割といろんなファイルごちゃごちゃしてるので、諸々整理した方が良さそうです🥳

--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -1,4 +1,44 @@
+const fs = require('fs')
+
 module.exports = (eleventyConfig) => {
+  // コレクションのキャッシュ用変数
+  let allPagesCache = []
+
+  // コレクションの作成
+  eleventyConfig.addCollection('allPages', function (collectionApi) {
+    // コレクションのデータをキャッシュ
+    allPagesCache = collectionApi.getAll().map((page) => ({
+      url: page.url,
+      inputPath: page.inputPath,
+      outputPath: page.outputPath
+    }))
+
+    console.log('Collection created with', allPagesCache.length, 'pages')
+    return allPagesCache
+  })
+
+  // ビルド完了後の処理
+  eleventyConfig.on('afterBuild', function () {
+    try {
+      console.log('afterBuild: Found', allPagesCache.length, 'pages')
+
+      if (!allPagesCache || allPagesCache.length === 0) {
+        console.warn('No pages found in collection')
+        return
+      }
+
+      // ページデータをJSON形式で保存
+      const pagesData = JSON.stringify(allPagesCache, null, 2)
+      fs.writeFileSync('dist/pages.json', pagesData)
+
+      console.log(
+        `Successfully wrote ${allPagesCache.length} pages to pages.json`
+      )
+    } catch (error) {
+      console.error('Error writing pages.json:', error)
+    }
+  })
+
   const eleventySass = require('eleventy-sass')
 
   // eleventy-sass プラグインを追加

--- a/package.json
+++ b/package.json
@@ -3,17 +3,20 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
     "clean": "rm -rf dist",
     "build": "npm run clean && eleventy",
     "serve": "eleventy --serve",
-    "watch": "eleventy --watch"
+    "watch": "eleventy --watch",
+    "test:a11y": "playwright test ./tests/accessibility.spec.js"
   },
   "author": "",
   "license": "ISC",
   "description": "",
   "devDependencies": {
     "@11ty/eleventy": "^2.0.1",
+    "@axe-core/playwright": "^4.10.1",
+    "@playwright/test": "^1.49.0",
+    "@types/node": "^22.9.1",
     "eleventy-sass": "^2.2.6",
     "prettier": "^3.3.3"
   }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,79 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// import path from 'path';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    baseURL: 'http://127.0.0.1:8080',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry'
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] }
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] }
+    }
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: 'npm run serve',
+    url: 'http://127.0.0.1:8080',
+    reuseExistingServer: !process.env.CI
+  }
+})

--- a/tests/accessibility.spec.js
+++ b/tests/accessibility.spec.js
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test'
+import AxeBuilder from '@axe-core/playwright'
+import { readFileSync } from 'fs'
+import path from 'path'
+
+// テスト設定の定義
+const config = {
+  baseUrl: 'http://127.0.0.1:8080', // 開発サーバーのURL
+  skipPaths: ['/404.html'] // スキップするパス
+}
+
+// ページリストの読み込み
+const pages = JSON.parse(
+  readFileSync(path.join(process.cwd(), 'dist/pages.json'), 'utf-8')
+)
+
+// 各ページに対してアクセシビリティテストを実行
+test.describe('Accessibility tests for all pages', () => {
+  for (const page of pages) {
+    // スキップするパスは除外
+    if (config.skipPaths.includes(page.url)) continue
+
+    test(`Testing accessibility on ${page.url}`, async ({
+      page: pageContext
+    }) => {
+      // ページへ移動
+      await pageContext.goto(`${config.baseUrl}${page.url}`)
+
+      // ページの読み込み完了を待機
+      await pageContext.waitForLoadState('networkidle')
+
+      // Axeによるアクセシビリティ分析の実行
+      const accessibilityScanResults = await new AxeBuilder({
+        page: pageContext
+      })
+        .withTags(['wcag2a', 'wcag2aa']) // WCAG 2.0 レベルAとAAのチェック
+        .analyze()
+
+      // 違反がないことを確認
+      expect(accessibilityScanResults.violations).toEqual([])
+
+      // 詳細なレポートの作成（違反がある場合）
+      if (accessibilityScanResults.violations.length > 0) {
+        console.log(`Accessibility violations found on ${page.url}:`)
+        accessibilityScanResults.violations.forEach((violation) => {
+          console.log(`\nRule: ${violation.id}`)
+          console.log(`Impact: ${violation.impact}`)
+          console.log(`Description: ${violation.help}`)
+          console.log('Affected elements:')
+          violation.nodes.forEach((node) => {
+            console.log(`- ${node.html}`)
+            console.log(`  ${node.failureSummary}`)
+          })
+        })
+      }
+    })
+  }
+})


### PR DESCRIPTION
とりあえず、自分なりに自動で全ページクロールできるようにしてみました。
おそらく`src`以下にある`[page_name].html`は全てクロールできると思っています。

とりあえずPR出していますが、マージするしないはお任せします🙏
emuさんがやってくれてる`sitemap.xml`方式の方が他プロジェクトでも活用できそうなので、このブランチからはコードとかファイル単位で流用して活用するでも良いと思います！

細かいところは`README.md`に記載しています〜